### PR TITLE
Refactor conversion loop to reduce code redundancy

### DIFF
--- a/src/euclideandistancekernels.jl
+++ b/src/euclideandistancekernels.jl
@@ -279,20 +279,14 @@ end
   Conversions
 ==========================================================================#
 
-for kernel in (:GaussianKernel, :LaplacianKernel, :RationalQuadraticKernel, :MultiQuadraticKernel, 
-               :InverseMultiQuadraticKernel, :PowerKernel, :LogKernel)
-    @eval begin
-        function convert{T<:FloatingPoint}(::Type{EuclideanDistanceKernel{T}}, κ::$kernel)
-            convert($kernel{T}, κ)
-        end
-        function convert{T<:FloatingPoint}(::Type{StandardKernel{T}}, κ::$kernel)
-            convert($kernel{T}, κ)
-        end
-        function convert{T<:FloatingPoint}(::Type{SimpleKernel{T}}, κ::$kernel)
-            convert($kernel{T}, κ)
-        end
-        function convert{T<:FloatingPoint}(::Type{Kernel{T}}, κ::$kernel)
-            convert($kernel{T}, κ)
+for kernel in (:GaussianKernel, :LaplacianKernel, :RationalQuadraticKernel,
+               :MultiQuadraticKernel, :InverseMultiQuadraticKernel,
+               :PowerKernel, :LogKernel)
+    for kerneltype in (:EuclideanDistanceKernel, :StandardKernel, :SimpleKernel, :Kernel)
+        @eval begin
+            function convert{T<:FloatingPoint}(::Type{$kerneltype{T}}, κ::$kernel)
+                convert($kernel{T}, κ)
+            end
         end
     end
 end

--- a/src/kernelmatrix.jl
+++ b/src/kernelmatrix.jl
@@ -205,7 +205,7 @@ function kernel_matrix{T<:FloatingPoint}(κ::StandardKernel{T}, X::Matrix{T}, Y:
     idx = trans == 'N' ? 2 : 1
     if size(X, idx) != size(Y, idx)
         throw(ArgumentError(
-                "X and Y have the same number of " * trans == 'N' ? "rows." : "columns."
+                "X and Y do not have the same number of " * trans == 'N' ? "rows." : "columns."
         ))
     end
     K::Matrix{T} = Array(T, n, m)

--- a/src/scalarproductkernels.jl
+++ b/src/scalarproductkernels.jl
@@ -146,18 +146,11 @@ end
 ==========================================================================#
 
 for kernel in (:LinearKernel, :PolynomialKernel, :SigmoidKernel)
-    @eval begin
-        function convert{T<:FloatingPoint}(::Type{ScalarProductKernel{T}}, κ::$kernel)
-            convert($kernel{T}, κ)
-        end
-        function convert{T<:FloatingPoint}(::Type{StandardKernel{T}}, κ::$kernel)
-            convert($kernel{T}, κ)
-        end
-        function convert{T<:FloatingPoint}(::Type{SimpleKernel{T}}, κ::$kernel)
-            convert($kernel{T}, κ)
-        end
-        function convert{T<:FloatingPoint}(::Type{Kernel{T}}, κ::$kernel)
-            convert($kernel{T}, κ)
+    for kerneltype in (:ScalarProductKernel, :StandardKernel, :SimpleKernel, :Kernel)
+        @eval begin
+            function convert{T<:FloatingPoint}(::Type{$kerneltype{T}}, κ::$kernel)
+                convert($kernel{T}, κ)
+            end
         end
     end
 end

--- a/src/separablekernels.jl
+++ b/src/separablekernels.jl
@@ -55,18 +55,11 @@ end
 ==========================================================================#
 
 for kernel in (:MercerSigmoidKernel,)
-    @eval begin
-        function convert{T<:FloatingPoint}(::Type{SeparableKernel{T}}, κ::$kernel)
-            convert($kernel{T}, κ)
-        end
-        function convert{T<:FloatingPoint}(::Type{StandardKernel{T}}, κ::$kernel)
-            convert($kernel{T}, κ)
-        end
-        function convert{T<:FloatingPoint}(::Type{SimpleKernel{T}}, κ::$kernel)
-            convert($kernel{T}, κ)
-        end
-        function convert{T<:FloatingPoint}(::Type{Kernel{T}}, κ::$kernel)
-            convert($kernel{T}, κ)
+    for kerneltype in (:SeparableKernel, :StandardKernel, :SimpleKernel, :Kernel)
+        @eval begin
+            function convert{T<:FloatingPoint}(::Type{$kerneltype{T}}, κ::$kernel)
+                convert($kernel{T}, κ)
+            end
         end
     end
 end


### PR DESCRIPTION
Hi,
I just came across your Kernel package for Julia, which I'd like to incorporate into my Gaussian Process code - rather than duplicating all the covariance kernels! To get a bit used to things I just refactored the loops at the bottom of the kernel files, removing code redundancy. All tests running fine.
