### PR TITLE
Update dependencies for 1.0 compatibility.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ julia:
 matrix:
   fast_finish: true
   allow_failures:
-    - julia: 1.0
     - julia: nightly
 
 notifications:

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -3,21 +3,21 @@ uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[BinDeps]]
 deps = ["Compat", "Libdl", "SHA", "URIParser"]
-git-tree-sha1 = "160d5d926e83e0970dd549ad9fe0ac3e8107e83c"
+git-tree-sha1 = "12093ca6cdd0ee547c39b1870e0c9c3f154d9ca9"
 uuid = "9e28174c-4ba2-5203-b857-d8d62c4213ee"
-version = "0.8.8"
+version = "0.8.10"
 
 [[BinaryProvider]]
-deps = ["Compat", "Pkg", "SHA"]
-git-tree-sha1 = "94dac52c662ca793008fb689e3daf626b6139943"
+deps = ["Libdl", "Pkg", "SHA", "Test"]
+git-tree-sha1 = "9930c1a6cd49d9fcd7218df6be417e6ae4f1468a"
 uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
-version = "0.3.3"
+version = "0.5.2"
 
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "c478aec93ea90bb99c307a92df17a76131bf275f"
+git-tree-sha1 = "2d9e14d19bad3f9ad5cc5e4cffabc3cfa59de825"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "1.0.0"
+version = "1.3.0"
 
 [[Dates]]
 deps = ["Printf"]
@@ -89,10 +89,10 @@ deps = ["LinearAlgebra", "Random"]
 uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [[SpecialFunctions]]
-deps = ["BinDeps", "BinaryProvider", "Compat", "Libdl"]
-git-tree-sha1 = "1cf00baba50536d254f02082c90b98d6e4e1f968"
+deps = ["BinDeps", "BinaryProvider", "Libdl", "Test"]
+git-tree-sha1 = "0b45dc2e45ed77f445617b99ff2adf0f5b0f23ea"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "0.6.0"
+version = "0.7.2"
 
 [[Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,6 @@ platform:
 
 matrix:
   allow_failures:
-  - julia_version: 1.0
   - julia_version: latest
 
 notifications:


### PR DESCRIPTION
Installing MLKernels on Julia 1.0 currently fails due to a dependency issue.
```
(v1.0) pkg> add MLKernels
  Updating registry at `~/.julia/registries/General`
  Updating git-repo `https://github.com/JuliaRegistries/General.git`
 Resolving package versions...
ERROR: Unsatisfiable requirements detected for package MLKernels [6899632a]:
 MLKernels [6899632a] log:
 ├─possible versions are: [0.0.1-0.0.3, 0.1.0, 0.2.0, 0.3.0] or uninstalled
 ├─restricted to versions * by an explicit requirement, leaving only versions [0.0.1-0.0.3, 0.1.0, 0.2.0, 0.3.0]
 └─restricted by julia compatibility requirements to versions: uninstalled — no versions left
```

With the newest release of SpecialFunctions.jl (https://github.com/JuliaLang/METADATA.jl/pull/19167) we can now update the dependencies of MLKernels.jl. This enables full compatibility for Julia 1.0 (CI passes).

Please trigger a new release on METADATA.jl after merging this to allow users to finally use this great package with Julia 1.0.

A test coverage drop may occur, see the bug and discussion here: https://github.com/JuliaLang/julia/issues/28192.