### PR TITLE
add constructor for RBFKernel

### DIFF
--- a/src/kernelfunctions/mercer/exponential.jl
+++ b/src/kernelfunctions/mercer/exponential.jl
@@ -104,9 +104,14 @@ const GaussianKernel = SquaredExponentialKernel
 """
     RadialBasisKernel([α=1])
 
-Alias of [`SquaredExponentialKernel`](@ref).
+Create a [`SquaredExponentialKernel`](@ref) using the following
+convention for [Radial Basis Function Kernel](https://en.wikipedia.org/wiki/Radial_basis_function_kernel).
+
+```
+κ(x,y) = exp(-‖x-y‖²/σ²)
+```
 """
-const RadialBasisKernel = SquaredExponentialKernel
+RadialBasisKernel(σ) = SquaredExponentialKernel(1/2σ^2)
 
 
 # Gamma Exponential Kernel =================================================================

--- a/src/kernelfunctions/mercer/exponential.jl
+++ b/src/kernelfunctions/mercer/exponential.jl
@@ -102,7 +102,7 @@ Alias of [`SquaredExponentialKernel`](@ref).
 const GaussianKernel = SquaredExponentialKernel
 
 """
-    RadialBasisKernel([α=1])
+    RadialBasisKernel([σ=1])
 
 Create a [`SquaredExponentialKernel`](@ref) using the following
 convention for [Radial Basis Function Kernel](https://en.wikipedia.org/wiki/Radial_basis_function_kernel).


### PR DESCRIPTION
Hi, folks

I'm just wondering if it make more sense to use the convention in wiki ([here](https://en.wikipedia.org/wiki/Radial_basis_function_kernel)) instead of just define it as an alias

I found it a little bit confusing (not very intuitive) while searching wiki, if this name does refer to RBF kernel, since it is completely the same to `SquaredExponentialKernel`...